### PR TITLE
[chore] : $pageDescription 追加と composer.json メタデータ補完 (P3)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,7 @@
 {
+    "name": "jantama/records",
+    "description": "雀魂麻雀トーナメント戦績サイト",
+    "license": "proprietary",
     "require": {
         "robmorgan/phinx": "^0.16",
         "vlucas/phpdotenv": "^5.6"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "94fbc8557c8dacfdc4d94804b667ec6f",
+    "content-hash": "e789da3e3a784fdc1f6aef346ce90b1a",
     "packages": [
         {
             "name": "cakephp/chronos",

--- a/public/player_edit.php
+++ b/public/player_edit.php
@@ -65,6 +65,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
 // --- テンプレート変数 ---
 $pageTitle = h($player['name']) . ' 編集 - ' . SITE_NAME;
+$pageDescription = $player['name'] . ' の選手情報を編集します。';
 $pageCss = ['css/forms.css'];
 $pageStyle = <<<'CSS'
 .edit-form { max-width: 600px; }

--- a/public/player_new.php
+++ b/public/player_new.php
@@ -59,6 +59,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
 // --- テンプレート変数 ---
 $pageTitle = '選手登録 - ' . SITE_NAME;
+$pageDescription = '新しい選手を登録します。';
 $pageCss = ['css/forms.css'];
 $pageStyle = <<<'CSS'
 .edit-form { max-width: 600px; }

--- a/public/table.php
+++ b/public/table.php
@@ -205,6 +205,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && !$isDone) {
 
 // --- テンプレート変数 ---
 $pageTitle = h($table['table_name']) . ' - ' . h($tournament['name']) . ' - ' . SITE_NAME;
+$pageDescription = $tournament['name'] . ' ' . $table['table_name'] . ' の対局情報・成績を管理します。';
 $pageCss = ['css/forms.css'];
 $pageStyle = <<<'CSS'
 .tb-hero { text-align: center; padding: 48px 20px 24px; }

--- a/public/table_new.php
+++ b/public/table_new.php
@@ -148,6 +148,7 @@ $jsPlayers = array_map(fn($p) => [
 
 // --- テンプレート変数 ---
 $pageTitle = '卓作成 - ' . h($tournament['name']) . ' - ' . SITE_NAME;
+$pageDescription = $tournament['name'] . ' の新しい卓を作成します。';
 $pageCss = ['css/forms.css'];
 $pageStyle = <<<'CSS'
 .tn-hero { text-align: center; padding: 48px 20px 24px; }

--- a/public/tournament_new.php
+++ b/public/tournament_new.php
@@ -108,6 +108,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
 // --- テンプレート変数 ---
 $pageTitle = '大会作成 - ' . SITE_NAME;
+$pageDescription = '新しい麻雀トーナメント大会を作成します。';
 $pageCss = ['css/forms.css'];
 $pageStyle = '';
 

--- a/public/tournament_players.php
+++ b/public/tournament_players.php
@@ -54,6 +54,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
 // --- テンプレート変数 ---
 $pageTitle = h($tournament['name']) . ' 選手登録 - ' . SITE_NAME;
+$pageDescription = $tournament['name'] . ' に参加する選手を登録します。';
 $pageCss = ['css/forms.css'];
 $pageStyle = '';
 


### PR DESCRIPTION
php-reviewer 監査で指摘された軽微な推奨事項を対応。

- $pageDescription 未設定 6 箇所に追加（SEO 用 meta description）
  - player_edit.php, player_new.php
  - table.php, table_new.php
  - tournament_new.php, tournament_players.php （header.php で h() 適用されるため生の文字列を代入）
- composer.json に name / description / license を追加 （composer validate --strict がパスするように）
- composer.lock を metadata 変更に追随